### PR TITLE
Update installation.rst with Mac OS X instructions

### DIFF
--- a/source/installation.rst
+++ b/source/installation.rst
@@ -71,5 +71,10 @@ For more information about manual builds, refer to the README file in the
 Installing on Mac OS X
 ----------------------
 
-*<to be written - contributions welcome.>*
+You can install libxml2 using homebrew::
+
+    brew install libxml2
+
+If you do not have Homebrew, you can install it at the `homebrew website
+<https://brew.sh/>`_.
 


### PR DESCRIPTION
I've added steps to install libxml2 with homebrew on Mac OS X, which is the predominant way people install packages on Mac OS X.